### PR TITLE
fix: add byte literals with characters up to utf-32be

### DIFF
--- a/src/pysource_codegen/_codegen.py
+++ b/src/pysource_codegen/_codegen.py
@@ -1611,7 +1611,7 @@ class AstGenerator:
                         "'\"'''\"\"\"{}\\",
                         b"'\"'''\"\"\"{}\\",
                         b"\xef\xbb\xbf",  # utf-8
-                        b"\xff\xfe\0\0",  # utf-16
+                        b"\xff\xfe\0\0",  # utf-32
                         b"\0\0\xfe\xff",  # utf-32be
                         b"\xff\xfe",  # utf-16
                         b"\xfe\xff",  # utf-16be

--- a/src/pysource_codegen/_codegen.py
+++ b/src/pysource_codegen/_codegen.py
@@ -1610,6 +1610,11 @@ class AstGenerator:
                         "",
                         "'\"'''\"\"\"{}\\",
                         b"'\"'''\"\"\"{}\\",
+                        b"\xef\xbb\xbf",  # utf-8
+                        b"\xff\xfe\0\0",  # utf-16
+                        b"\0\0\xfe\xff",  # utf-32be
+                        b"\xff\xfe",  # utf-16
+                        b"\xfe\xff",  # utf-16be
                         self.rand.randint(0, 20),
                         self.rand.uniform(0, 20),
                         True,


### PR DESCRIPTION
Hi,

First of all, big thanks for this project. I use it for fuzzing in my newly created rustpython-unparser library and it helped me a lot with reaching a satisfying result fast.

However, when using my unparser with real world code bases I realised that it couldn't handle byte literals that contain non-utf-8 characters. Therefore, I thought it would be good if pysource-codegen outputs code with such byte literals so that such errors can be catched by fuzzing in the future. The examples  I added come from the `pygments.lexer` module.